### PR TITLE
Build a container based on the red hat buildah runner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Push Image to Public Container Registry
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: python-runner
+      IMAGE_NAME: buildah-runner
       REGISTRY: quay.io/aagreen
     steps:
       - name: Clone the Repository

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
-FROM quay.io/redhat-github-actions/runner
+FROM quay.io/redhat-github-actions/buildah-runner
 
 USER root
-RUN dnf install -y python3-pip maven buildah skopeo
+RUN dnf install -y python3-pip maven skopeo
 RUN pip install --upgrade git+https://github.com/ploigos/ploigos-step-runner.git@main
 
 USER $UID

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Based on the [OpenShift Github Actions Runners](https://github.com/redhat-action
 This repository has a Github Actions workflow that automatically builds and publishes changes to the image.
 ## Building Image Manually
 ```shell
-buildah bud -t quay.io/dwinchell_redhat/python-runner .
-podman push quay.io/dwinchell_redhat/python-runner 
+buildah bud -t quay.io/aagreen/buildah-runner .
+podman push quay.io/aagreen/buildah-runner
 ```
 
 ## Contributing


### PR DESCRIPTION
Built a container file using `quay.io/redhat-github-actions/buildah-runner` as the base.